### PR TITLE
[Home] feature: 사용자 인증 정보 갱신을 위한 로그인 화면 전환

### DIFF
--- a/YonderTrips/YonderTrips/Data/Network/AuthNetworkError.swift
+++ b/YonderTrips/YonderTrips/Data/Network/AuthNetworkError.swift
@@ -1,0 +1,13 @@
+//
+//  AuthNetworkError.swift
+//  YonderTrips
+//
+//  Created by 임윤휘 on 6/9/25.
+//
+
+import Foundation
+
+enum AuthNetworkError: Error {
+    case accessTokenExpired
+    case refreshTokenExpired
+}

--- a/YonderTrips/YonderTrips/Data/Network/NetworkService.swift
+++ b/YonderTrips/YonderTrips/Data/Network/NetworkService.swift
@@ -7,11 +7,6 @@
 
 import SwiftUI
 
-enum AuthNetworkError: Error {
-    case accessTokenExpired
-    case refreshTokenExpired
-}
-
 struct NetworkService {
     
     private let session = URLSession.shared

--- a/YonderTrips/YonderTrips/Presentation/DIContainer.swift
+++ b/YonderTrips/YonderTrips/Presentation/DIContainer.swift
@@ -45,16 +45,16 @@ extension DIContainer {
         return EmailSignInViewModel(signInUseCase: signInUseCase)
     }
     
-    func makeNewActivityViewModel() -> NewActivityViewModel {
+    func makeNewActivityViewModel(onError errorHandler: @escaping (String) -> Void) -> NewActivityViewModel {
         
         let newActivityUseCase = NewActivityUseCase()
-        return NewActivityViewModel(newActivityUseCase: newActivityUseCase)
+        return NewActivityViewModel(newActivityUseCase: newActivityUseCase, onError: errorHandler)
     }
     
-    func makeActivityPostViewModel() -> ActivityPostViewModel {
+    func makeActivityPostViewModel(onError errorHandler: @escaping (String) -> Void) -> ActivityPostViewModel {
         
         let activityPostUseCase = ActivityPostUseCase()
-        return ActivityPostViewModel(activityPostUseCase: activityPostUseCase)
+        return ActivityPostViewModel(activityPostUseCase: activityPostUseCase, onError: errorHandler)
     }
 }
 

--- a/YonderTrips/YonderTrips/Presentation/HomeView/ActivityPost/ActivityPostViewModel.swift
+++ b/YonderTrips/YonderTrips/Presentation/HomeView/ActivityPost/ActivityPostViewModel.swift
@@ -12,9 +12,17 @@ final class ActivityPostViewModel: ViewModelType {
     @Published var state = State()
     
     private let activityPostUseCase: ActivityPostUseCase
+    private var onError: ((String) -> Void)?
     
     init(activityPostUseCase: ActivityPostUseCase) {
         self.activityPostUseCase = activityPostUseCase
+    }
+    
+    init(activityPostUseCase: ActivityPostUseCase, onError: ((String) -> Void)? = nil) {
+        self.activityPostUseCase = activityPostUseCase
+        self.onError = onError
+        
+        binding()
     }
     
     struct State {
@@ -47,7 +55,7 @@ extension ActivityPostViewModel {
                     
                     state.postSummaryList = pagination.data
                 } catch {
-                    YonderTripsLogger.shared.debug("Falied to fetch activity post: \(error)")
+                    onError?("사용자 인증이 만료되었습니다.\n다시 로그인 해주세요.")
                 }
             }
         }

--- a/YonderTrips/YonderTrips/Presentation/HomeView/HomeView.swift
+++ b/YonderTrips/YonderTrips/Presentation/HomeView/HomeView.swift
@@ -10,7 +10,11 @@ import SwiftUI
 struct HomeView: View {
     
     @Environment(\.container) var container
+    @EnvironmentObject private var router: RootFlowRouter
     @StateObject private var homeRouter = HomeFlowRouter()
+    
+    @State private var showErrorPopup = false
+    @State private var errorMessage: String = ""
     
     var body: some View {
         
@@ -26,7 +30,7 @@ struct HomeView: View {
                             .foregroundStyle(.deepSeafoam)
                     }
                     
-                    NewActivityView(viewModel: container.makeNewActivityViewModel())
+                    NewActivityView(viewModel: container.makeNewActivityViewModel(onError: handleRefreshError))
                         .frame(maxWidth: .infinity)
                         .frame(height: 360)
                         .padding(.bottom, 8)
@@ -48,7 +52,7 @@ struct HomeView: View {
                     }
                     .background(.gray0)
                     
-                    ActivityPostView(viewModel: container.makeActivityPostViewModel())
+                    ActivityPostView(viewModel: container.makeActivityPostViewModel(onError: handleRefreshError))
                 }
             }
             .background(.gray15)
@@ -63,6 +67,13 @@ struct HomeView: View {
                             .frame(width: 24, height: 24)
                             .foregroundStyle(.gray75)
                     }
+                }
+            }
+            .overlay {
+                if showErrorPopup {
+                    PopupView(title: errorMessage,
+                              isPresented: $showErrorPopup,
+                              action: handleOnErrorPopup)
                 }
             }
             .ytNavigationDestination(for: HomeFlowRouter.HomeFlow.self) { flow in
@@ -88,6 +99,15 @@ struct HomeView: View {
 
 //MARK: - Action
 private extension HomeView {
+    
+    func handleRefreshError(_ message: String) {
+        errorMessage = message
+        showErrorPopup = true
+    }
+    
+    func handleOnErrorPopup() {
+        router.rootFlow = .signIn
+    }
     
     func handleNewActivityViewAll() {
         homeRouter.path.append(HomeFlowRouter.HomeFlow.activityFilter(.none, .none))

--- a/YonderTrips/YonderTrips/Presentation/HomeView/NewActivityView/NewActivityViewModel.swift
+++ b/YonderTrips/YonderTrips/Presentation/HomeView/NewActivityView/NewActivityViewModel.swift
@@ -12,9 +12,11 @@ final class NewActivityViewModel: ViewModelType {
     @Published var state = State()
     
     private let newActivityUseCase: NewActivityUseCase
+    private var onError: ((String) -> Void)?
     
-    init(newActivityUseCase: NewActivityUseCase) {
+    init(newActivityUseCase: NewActivityUseCase, onError: ((String) -> Void)? = nil) {
         self.newActivityUseCase = newActivityUseCase
+        self.onError = onError
         
         binding()
     }
@@ -74,7 +76,7 @@ extension NewActivityViewModel {
                     state.activityList = activityList
                     
                 } catch let error as AuthNetworkError where error == .refreshTokenExpired {
-                    print("회원 인증 시간 만료 alert 띄우기")
+                    onError?("사용자 인증이 만료되었습니다.\n다시 로그인 해주세요.")
                 }
             }
         }

--- a/YonderTrips/YonderTrips/Presentation/Popup/PopupView.swift
+++ b/YonderTrips/YonderTrips/Presentation/Popup/PopupView.swift
@@ -11,6 +11,13 @@ struct PopupView: View {
     
     let title: String
     @Binding var isPresented: Bool
+    let action: (() -> Void)?
+    
+    init(title: String, isPresented: Binding<Bool>, action: (() -> Void)? = nil) {
+        self.title = title
+        self._isPresented = isPresented
+        self.action = action
+    }
     
     var body: some View {
         
@@ -28,6 +35,7 @@ struct PopupView: View {
                 
                 Button {
                     isPresented = false
+                    action?()
                 } label: {
                     Text("확인")
                         .foregroundStyle(.gray0)


### PR DESCRIPTION
## related
#19

<br>


## 구현
- HomeView에서 리프레시 토큰 만료 오류를 해결하는 Handler를 두어 하위 뷰의 view model에서 만료 오류 발생 시 해당 handler를 호출하도록 구현

<br>

## 이슈
- 전역적으로 사용할 수 있도록 리프레시 토큰 만료 대응 로직 분리 필요

<br>

## 미리보기



<br>


closed #19

<br>
