### PR TITLE
[ActivityList] feature: 액티비티 화면 API 통신

### DIFF
--- a/YonderTrips/YonderTrips/Data/DTO/Response/Activity/ActivitySummaryListResponseDTO.swift
+++ b/YonderTrips/YonderTrips/Data/DTO/Response/Activity/ActivitySummaryListResponseDTO.swift
@@ -1,0 +1,24 @@
+//
+//  ActivitySummaryListResponseDTO.swift
+//  YonderTrips
+//
+//  Created by 임윤휘 on 6/11/25.
+//
+
+import Foundation
+
+struct ActivitySummaryListResponseDTO: Decodable {
+    let data: [ActivitySummaryResponseDTO]
+    let nextCursor: String
+    
+    enum CodingKeys: String, CodingKey {
+        case data
+        case nextCursor = "next_cursor"
+    }
+    
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        data = try container.decodeIfPresent([ActivitySummaryResponseDTO].self, forKey: .data) ?? []
+        nextCursor = try container.decodeIfPresent(String.self, forKey: .nextCursor) ?? ""
+    }
+}

--- a/YonderTrips/YonderTrips/Data/DTO/Response/Activity/ActivitySummaryListResponseDTO.swift
+++ b/YonderTrips/YonderTrips/Data/DTO/Response/Activity/ActivitySummaryListResponseDTO.swift
@@ -22,3 +22,13 @@ struct ActivitySummaryListResponseDTO: Decodable {
         nextCursor = try container.decodeIfPresent(String.self, forKey: .nextCursor) ?? ""
     }
 }
+
+extension ActivitySummaryListResponseDTO {
+    
+    func toEntity() -> ActivitySummaryList {
+        ActivitySummaryList(
+            data: data.map { $0.toEntity() },
+            nextCursor: nextCursor
+        )
+    }
+}

--- a/YonderTrips/YonderTrips/Data/Network/API/YonderTripsActivityAPI.swift
+++ b/YonderTrips/YonderTrips/Data/Network/API/YonderTripsActivityAPI.swift
@@ -10,6 +10,7 @@ import Foundation
 enum YonderTripsActivityAPI: APIConfiguration, APIErrorConvertible {
     case new(ActivityCountry, ActivityCategory)
     case detail(String)
+    case activities(ActivityCountry, ActivityCategory, String)
     
     var url: URL? {
         return urlComponents.url
@@ -17,7 +18,7 @@ enum YonderTripsActivityAPI: APIConfiguration, APIErrorConvertible {
     
     var method: String {
         switch self {
-        case .new, .detail:
+        case .new, .detail, .activities:
             return HTTPMethod.get
         }
     }
@@ -27,6 +28,10 @@ enum YonderTripsActivityAPI: APIConfiguration, APIErrorConvertible {
         case let .new(country, category):
             return [URLQueryItem(name: "country", value: country.query),
                     URLQueryItem(name: "category", value: category.query)]
+        case let .activities(country, category, id):
+            return [URLQueryItem(name: "country", value: country.query),
+                    URLQueryItem(name: "category", value: category.query),
+                    URLQueryItem(name: "next", value: id)]
         default:
             return nil
         }
@@ -72,6 +77,8 @@ private extension YonderTripsActivityAPI {
             return "new"
         case .detail(let id):
             return id
+        case .activities:
+            return "activities"
         }
     }
 }

--- a/YonderTrips/YonderTrips/Data/Network/API/YonderTripsActivityAPI.swift
+++ b/YonderTrips/YonderTrips/Data/Network/API/YonderTripsActivityAPI.swift
@@ -78,7 +78,7 @@ private extension YonderTripsActivityAPI {
         case .detail(let id):
             return id
         case .activities:
-            return "activities"
+            return ""
         }
     }
 }

--- a/YonderTrips/YonderTrips/Domain/Entity/ActivityCountry.swift
+++ b/YonderTrips/YonderTrips/Domain/Entity/ActivityCountry.swift
@@ -28,7 +28,7 @@ enum ActivityCountry: String, CaseIterable {
         case .japan:
             return "일본"
         case .australia:
-            return "오스트레일리아"
+            return "호주"
         }
     }
     
@@ -45,7 +45,7 @@ enum ActivityCountry: String, CaseIterable {
         case .japan:
             return "일본"
         case .australia:
-            return "오스트레일리아"
+            return "호주"
         }
     }
     

--- a/YonderTrips/YonderTrips/Domain/Entity/ActivitySummaryList.swift
+++ b/YonderTrips/YonderTrips/Domain/Entity/ActivitySummaryList.swift
@@ -1,0 +1,13 @@
+//
+//  ActivitySummaryList.swift
+//  YonderTrips
+//
+//  Created by 임윤휘 on 6/11/25.
+//
+
+import Foundation
+
+struct ActivitySummaryList {
+    let data: [ActivitySummary]
+    let nextCursor: String
+}

--- a/YonderTrips/YonderTrips/Domain/UseCase/ActivityUseCase.swift
+++ b/YonderTrips/YonderTrips/Domain/UseCase/ActivityUseCase.swift
@@ -1,0 +1,27 @@
+//
+//  ActivityUseCase.swift
+//  YonderTrips
+//
+//  Created by 임윤휘 on 6/11/25.
+//
+
+import Foundation
+
+struct ActivityUseCase {
+    
+    func requestActivityList(
+        country: ActivityCountry,
+        catergory: ActivityCategory,
+        id: String
+    ) async throws -> ActivitySummaryList {
+        
+        let response: ActivitySummaryListResponseDTO = try await NetworkService.requestWithAuth(apiProvider: .activity(.activities(country, catergory, id)))
+        return response.toEntity()
+    }
+    
+    func requestActivityDetail(with activityId: String) async throws -> Activity
+    {
+        let response: ActivityResponseDTO = try await NetworkService.requestWithAuth(apiProvider: .activity(.detail(activityId)))
+        return response.toEntity()
+    }
+}

--- a/YonderTrips/YonderTrips/Domain/UseCase/NewActivityUseCase.swift
+++ b/YonderTrips/YonderTrips/Domain/UseCase/NewActivityUseCase.swift
@@ -17,10 +17,4 @@ struct NewActivityUseCase {
         return response.data.map { $0.toEntity() }
 
     }
-    
-    func requestNewActivityDetail(with activityId: String) async throws -> Activity
-    {
-        let response: ActivityResponseDTO = try await NetworkService.requestWithAuth(apiProvider: .activity(.detail(activityId)))
-        return response.toEntity()
-    }
 }

--- a/YonderTrips/YonderTrips/Presentation/ActivityList/ActivityListCellView.swift
+++ b/YonderTrips/YonderTrips/Presentation/ActivityList/ActivityListCellView.swift
@@ -9,6 +9,8 @@ import SwiftUI
 
 struct ActivityListCellView: View {
     
+    let activity: Activity
+    
     var body: some View {
         
         VStack(spacing: 0) {
@@ -16,7 +18,7 @@ struct ActivityListCellView: View {
             VStack {
                 ZStack(alignment: .trailing) {
                     
-                    DataImageView(urlString: "")
+                    DataImageView(urlString: activity.imageThumbnail)
                         .frame(height: 200)
                         .frame(maxWidth: .infinity)
                         .overlay {
@@ -24,9 +26,12 @@ struct ActivityListCellView: View {
                         }
                     
                     VStack(alignment: .trailing) {
-                        LocationTagView(country: "대한민국")
+                        LocationTagView(country: activity.country)
                         Spacer()
-                        AdvertisementTagView(isAdvertisement: true)
+                        
+                        if activity.isAdvertisement {
+                            AdvertisementTagView()
+                        }
                     }
                     .padding(16)
                     
@@ -36,14 +41,17 @@ struct ActivityListCellView: View {
                 .background(Color.black)
                 .cornerRadius(25)
                 
-                ActivityTagView(tag: "NEW 오픈 특가")
-                    .padding(.top, -25)
+                if !activity.tags.isEmpty,
+                   let tag = activity.tags.first {
+                    ActivityTagView(tag: tag)
+                        .padding(.top, -25)
+                }
             }
             
             VStack(alignment: .leading, spacing: 8) {
                 
                 HStack {
-                    Text("새싹 패러글라이딩 2기")
+                    Text(activity.title)
                         .font(.yt(.pretendard(.body1)))
                         .foregroundColor(.gray90)
                     
@@ -54,7 +62,7 @@ struct ActivityListCellView: View {
                             .frame(width: 20, height: 20)
                             .foregroundColor(.lightSeafoam)
                         
-                        Text("\(88)")
+                        Text("\(activity.keepCount)")
                             .font(.yt(.paperlogy(.caption2)))
                             .foregroundStyle(.gray60)
                     }
@@ -65,14 +73,14 @@ struct ActivityListCellView: View {
                             .frame(width: 20, height: 20)
                             .foregroundStyle(.blackSeafoam)
                         
-                        Text("\(88)P")
+                        Text("\(activity.pointReward)P")
                             .font(.yt(.paperlogy(.caption2)))
                             .foregroundStyle(.gray60)
                     }
                 }
                 .padding(.top, 16)
                 
-                Text("두려움을 넘고, 하늘을 향한 두 번째 도전이 시작됩니다. 아직은 서툴지만, 하늘을 향한 마음은 누구보다 단단한 새싹들의 비상.")
+                Text(activity.description)
                     .font(.yt(.pretendard(.caption1)))
                     .foregroundColor(.gray75)
                     .lineLimit(3)
@@ -80,7 +88,7 @@ struct ActivityListCellView: View {
                 HStack {
                     HStack(spacing: 24) {
                         // TODO: - 금액 숫자 형식 적용
-                        Text(String("\(12000)원"))
+                        Text(String("\(activity.price.original)원"))
                             .font(.yt(.pretendard(.body1)))
                             .foregroundColor(.gray45)
                             .overlay {
@@ -89,7 +97,7 @@ struct ActivityListCellView: View {
                                     .padding(.trailing, -16)
                                     .foregroundStyle(.blackSeafoam)
                             }
-                        Text(String("\(12000)원"))
+                        Text(String("\(activity.price.final)원"))
                             .font(.yt(.pretendard(.body1)))
                             .foregroundColor(.gray90)
                     }
@@ -111,9 +119,4 @@ struct ActivityListCellView: View {
         .padding(.vertical, 8)
         .padding(.horizontal, 16)
     }
-}
-
-
-#Preview {
-    ActivityListCellView()
 }

--- a/YonderTrips/YonderTrips/Presentation/ActivityList/ActivityListView.swift
+++ b/YonderTrips/YonderTrips/Presentation/ActivityList/ActivityListView.swift
@@ -9,8 +9,7 @@ import SwiftUI
 
 struct ActivityListView: View {
     
-    let selectedCategory: ActivityCategory
-    let selectedCountry: ActivityCountry
+    @StateObject var viewModel: ActivityListViewModel
     
     var body: some View {
         
@@ -24,8 +23,8 @@ struct ActivityListView: View {
                 HeaderView<EmptyView>(title: "액티비티")
                 
                 VStack {
-                    ForEach(0..<10) { _ in
-                        ActivityListCellView()
+                    ForEach(viewModel.state.activityList, id: \.activityId) { activity in
+                        ActivityListCellView(activity: activity)
                         
                         VerticalDivider()
                     }
@@ -35,12 +34,11 @@ struct ActivityListView: View {
         .background(.gray15)
         .toolbar {
             ToolbarItem(placement: .principal) {
-                NavigationTitleView(title: selectedCategory.title_en)
+                NavigationTitleView(title: viewModel.category.title_en)
             }
         }
+        .onAppear {
+            viewModel.action(.onAppear)
+        }
     }
-}
-
-#Preview {
-    ActivityListView(selectedCategory: .exciting, selectedCountry: .none)
 }

--- a/YonderTrips/YonderTrips/Presentation/DIContainer.swift
+++ b/YonderTrips/YonderTrips/Presentation/DIContainer.swift
@@ -48,13 +48,20 @@ extension DIContainer {
     func makeNewActivityViewModel(onError errorHandler: @escaping (String) -> Void) -> NewActivityViewModel {
         
         let newActivityUseCase = NewActivityUseCase()
-        return NewActivityViewModel(newActivityUseCase: newActivityUseCase, onError: errorHandler)
+        let activityUseCase = ActivityUseCase()
+        return NewActivityViewModel(newActivityUseCase: newActivityUseCase, activityUseCase: activityUseCase, onError: errorHandler)
     }
     
     func makeActivityPostViewModel(onError errorHandler: @escaping (String) -> Void) -> ActivityPostViewModel {
         
         let activityPostUseCase = ActivityPostUseCase()
         return ActivityPostViewModel(activityPostUseCase: activityPostUseCase, onError: errorHandler)
+    }
+    
+    func makeActivityListViewModel(category: ActivityCategory, country: ActivityCountry) -> ActivityListViewModel {
+        
+        let activityUseCase = ActivityUseCase()
+        return ActivityListViewModel(activityUseCase: activityUseCase, category: category, country: country)
     }
 }
 

--- a/YonderTrips/YonderTrips/Presentation/DesignSystem/Component/AdvertisementTagView.swift
+++ b/YonderTrips/YonderTrips/Presentation/DesignSystem/Component/AdvertisementTagView.swift
@@ -9,35 +9,28 @@ import SwiftUI
 
 struct AdvertisementTagView: View {
     
-    let isAdvertisement: Bool
-    
     var body: some View {
         
-        if !isAdvertisement {
-            EmptyView()
+        HStack {
+            Image(systemName: "info.circle")
+                .resizable()
+                .frame(width: 12, height: 12)
             
-        } else {
-            HStack {
-                Image(systemName: "info.circle")
-                    .resizable()
-                    .frame(width: 12, height: 12)
-                
-                Text("광고")
-                    .font(.yt(.pretendard(.caption3)))
-            }
-            .foregroundColor(.gray0)
-            .padding(.vertical, 3)
-            .padding(.horizontal, 5)
-            .background(.gray0.opacity(0.45))
-            .cornerRadius(15)
-            .overlay {
-                RoundedRectangle(cornerRadius: 15)
-                    .stroke(.gray0, lineWidth: 0.6)
-            }
+            Text("광고")
+                .font(.yt(.pretendard(.caption3)))
+        }
+        .foregroundColor(.gray0)
+        .padding(.vertical, 3)
+        .padding(.horizontal, 5)
+        .background(.gray0.opacity(0.45))
+        .cornerRadius(15)
+        .overlay {
+            RoundedRectangle(cornerRadius: 15)
+                .stroke(.gray0, lineWidth: 0.6)
         }
     }
 }
 
 #Preview {
-    AdvertisementTagView(isAdvertisement: true)
+    AdvertisementTagView()
 }

--- a/YonderTrips/YonderTrips/Presentation/HomeView/HomeView.swift
+++ b/YonderTrips/YonderTrips/Presentation/HomeView/HomeView.swift
@@ -81,7 +81,7 @@ struct HomeView: View {
                 
                 switch flow {
                 case let .activityList(category, country):
-                    ActivityListView(selectedCategory: category, selectedCountry: country)
+                    ActivityListView(viewModel: container.makeActivityListViewModel(category: category, country: country))
                 case .activityDetail:
                     Text("")
                 case let .activityPostList(category, country):


### PR DESCRIPTION
## related
#23 

<br>


## 구현

### Activity API
- activities API 구성 및 연결
- DTO와 Entity 생성 및 Mapper 메서드 구현

### Activity List 데이터 바인딩
- ActivityListCellView와 ActivityDetail API 응답 데이터 바인딩

### ActivityUseCase
- requestActivityDetail 메서드 위치 변경 (NewActivityUseCase -> ActivityUseCase)

### ActivityDetail 병렬적 호출
- withTaskGroup을 사용해 Activity 목록의 각 원소들의 detail을 병렬적으로 호출

```swift

Task {
    do {
        ...
        let activityList: [Activity] = await withTaskGroup(of: Activity?.self) { group in
            for summary in state.activitySummaryList {
                group.addTask { [weak self] in
                    guard let self else { return nil }
                    
                    do {
                        return try await self.activityUseCase.requestActivityDetail(with: summary.activityId)
                    } catch {
                        YonderTripsLogger.shared.debug("Failed to fetch activity detail")
                        return nil
                    }
                }
            }
            
            ...
}
```



<br>

## 이슈
-  cursor 기반 페이지네이션 구성하기
- Banner API 연결





<br>

## 미리보기


| 미리보기 |
| ----- |
| <img src = "https://github.com/user-attachments/assets/ed0764df-59d8-490f-9d4e-fb39effc4987" width = 260 height = 560> |


closed #23

<br>
