### PR TITLE
[ActivityDetail] feature: 액티비티 상세 화면 UI 구성

### DIFF
--- a/YonderTrips/YonderTrips/Common/Utility/YTDateFormatter.swift
+++ b/YonderTrips/YonderTrips/Common/Utility/YTDateFormatter.swift
@@ -1,0 +1,48 @@
+//
+//  YTDateFormatter.swift
+//  YonderTrips
+//
+//  Created by 임윤휘 on 6/19/25.
+//
+
+import Foundation
+
+struct YTDateFormatter {
+    
+    enum Format {
+        case iso8601
+        case yyyyMMdd
+    }
+    
+    static private let iso8601Formatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
+        return formatter
+    }()
+    
+    static private let yyyyMMddFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter
+    }()
+    
+    static func string(from date: Date, format: Format) -> String {
+        
+        switch format {
+        case .iso8601:
+            return iso8601Formatter.string(from: date)
+        case .yyyyMMdd:
+            return yyyyMMddFormatter.string(from: date)
+        }
+    }
+    
+    static func date(from string: String, format: Format) -> Date? {
+        
+        switch format {
+        case .iso8601:
+            return iso8601Formatter.date(from: string)
+        case .yyyyMMdd:
+            return yyyyMMddFormatter.date(from: string)
+        }
+    }
+}

--- a/YonderTrips/YonderTrips/Domain/Entity/ActivityEntity/ActivityReservationItem.swift
+++ b/YonderTrips/YonderTrips/Domain/Entity/ActivityEntity/ActivityReservationItem.swift
@@ -11,3 +11,14 @@ struct ActivityReservationItem: Hashable {
     let itemName: String
     let times: [ActivityReservationTime]
 }
+
+extension ActivityReservationItem {
+    
+    var itemDate: Date? {
+        YTDateFormatter.date(from: itemName, format: .yyyyMMdd)
+    }
+    
+    var isFullyReserved: Bool {
+        times.first{ !$0.isReserved } == nil
+    }
+}

--- a/YonderTrips/YonderTrips/Presentation/ActivityDetail/ActivityCurriculum/ActivityCurriculumView.swift
+++ b/YonderTrips/YonderTrips/Presentation/ActivityDetail/ActivityCurriculum/ActivityCurriculumView.swift
@@ -1,0 +1,41 @@
+//
+//  ActivityCurriculumView.swift
+//  YonderTrips
+//
+//  Created by 임윤휘 on 6/18/25.
+//
+
+import SwiftUI
+
+struct ActivityCurriculumView: View {
+    
+    let items: [ActivityScheduleItem] = [
+        ActivityScheduleItem(duration: "시작 - 15분", description: "안전 교육 및 준비 시간이 포함됩니다."),
+        ActivityScheduleItem(duration: "30분 - 1시간", description: "기본 훈련 및 장비 점검"),
+        ActivityScheduleItem(duration: "1시간 - 2시간", description: "본격적인 체험 시작"),
+        ActivityScheduleItem(duration: "마무리 - 20분", description: "정리 및 피드백 시간")
+    ]
+    
+    var body: some View {
+        
+        VStack(alignment: .leading, spacing: -16) {
+            ForEach(items, id: \.self) { item in
+                
+                VStack(alignment: .leading, spacing: 4) {
+                    ActivityScheduleCellView(item: item)
+                    
+                    if let last = items.last, last != item {
+                        Color.lightSeafoam
+                            .frame(width: 2, height: 28)
+                            .padding(.leading, 3)
+                    }
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    ActivityCurriculumView()
+}
+

--- a/YonderTrips/YonderTrips/Presentation/ActivityDetail/ActivityCurriculum/ActivityCurriculumView.swift
+++ b/YonderTrips/YonderTrips/Presentation/ActivityDetail/ActivityCurriculum/ActivityCurriculumView.swift
@@ -18,20 +18,40 @@ struct ActivityCurriculumView: View {
     
     var body: some View {
         
-        VStack(alignment: .leading, spacing: -16) {
-            ForEach(items, id: \.self) { item in
-                
-                VStack(alignment: .leading, spacing: 4) {
-                    ActivityScheduleCellView(item: item)
+        VStack(alignment: .leading, spacing: 0) {
+            
+            SubheaderView(title: "액티비티 커리큘럼")
+            
+            VStack(alignment: .leading, spacing: 30) {
+                VStack(alignment: .leading, spacing: -16) {
                     
-                    if let last = items.last, last != item {
-                        Color.lightSeafoam
-                            .frame(width: 2, height: 28)
-                            .padding(.leading, 3)
+                    ForEach(items, id: \.self) { item in
+                        
+                        VStack(alignment: .leading, spacing: 4) {
+                            ActivityScheduleCellView(item: item)
+                            
+                            if let last = items.last, last != item {
+                                Color.lightSeafoam
+                                    .frame(width: 2, height: 28)
+                                    .padding(.leading, 3)
+                            }
+                        }
                     }
                 }
+                
+                LocationView(region: ActivityGeolocation(longitude: 46.3997, latitude: 8.1286))
             }
+            .padding(20)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(.gray0)
+            .clipShape(RoundedRectangle(cornerRadius: 15))
+            .overlay {
+                RoundedRectangle(cornerRadius: 15)
+                    .stroke(.gray30, lineWidth: 0.6)
+            }
+            .padding(.horizontal, 16)
         }
+        .frame(maxWidth: .infinity)
     }
 }
 

--- a/YonderTrips/YonderTrips/Presentation/ActivityDetail/ActivityCurriculum/ActivityScheduleCellView.swift
+++ b/YonderTrips/YonderTrips/Presentation/ActivityDetail/ActivityCurriculum/ActivityScheduleCellView.swift
@@ -1,0 +1,38 @@
+//
+//  ActivityScheduleCellView.swift
+//  YonderTrips
+//
+//  Created by 임윤휘 on 6/18/25.
+//
+
+import SwiftUI
+
+struct ActivityScheduleCellView: View {
+    
+    let item: ActivityScheduleItem
+    
+    var body: some View {
+        
+        VStack(alignment: .leading, spacing: 4) {
+            Text(item.duration)
+                .font(.yt(.pretendard(.caption2)))
+                .foregroundStyle(.gray45)
+                .padding(.leading, 20)
+            
+            HStack(spacing: 12) {
+                
+                Color.lightSeafoam
+                    .clipShape(.circle)
+                    .frame(width: 8, height: 8)
+                
+                Text(item.description)
+                    .font(.yt(.pretendard(.body3)).weight(.bold))
+                    .foregroundStyle(.gray75)
+            }
+        }
+    }
+}
+
+#Preview {
+    ActivityScheduleCellView(item: ActivityScheduleItem(duration: "시작 - 10분", description: "부상 방지를 위한 기본 스트레칭"))
+}

--- a/YonderTrips/YonderTrips/Presentation/ActivityDetail/ActivityCurriculum/LocationView.swift
+++ b/YonderTrips/YonderTrips/Presentation/ActivityDetail/ActivityCurriculum/LocationView.swift
@@ -1,0 +1,75 @@
+//
+//  LocationView.swift
+//  YonderTrips
+//
+//  Created by 임윤휘 on 6/18/25.
+//
+
+import SwiftUI
+import MapKit
+
+struct LocationView: View {
+    
+    let region: ActivityGeolocation
+    
+    @State private var coordinateRegion: MKCoordinateRegion
+    private let coordinate: CLLocationCoordinate2D
+    
+    init(region: ActivityGeolocation) {
+        self.region = region
+        
+        self.coordinate = CLLocationCoordinate2D(latitude: region.latitude, longitude: region.longitude)
+        let span = MKCoordinateSpan(latitudeDelta: 5.0, longitudeDelta: 5.0)
+        self.coordinateRegion = MKCoordinateRegion(center: coordinate, span: span)
+    }
+    
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            
+            mapView()
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(.gray30, lineWidth: 0.6)
+                }
+            
+            VStack(alignment: .leading, spacing: 5) {
+                Text("용프라우, 스위스")
+                    .font(.yt(.pretendard(.body3)).weight(.bold))
+                    .foregroundStyle(.gray75)
+                
+                Text("3984 GXP7+P2 Fieschertal, Swiss")
+                    .font(.yt(.pretendard(.caption1)))
+                    .foregroundStyle(.gray45)
+            }
+        }
+    }
+}
+
+//MARK: - View
+extension LocationView {
+    
+    @ViewBuilder
+    func mapView() -> some View {
+        
+        if #available(iOS 17.0, *) {
+            Map(bounds: MapCameraBounds(centerCoordinateBounds: coordinateRegion)) {
+                Marker("용프라우, 스위스", coordinate: coordinate)
+            }
+            .frame(width: 80, height: 80)
+        } else {
+            Map(coordinateRegion: $coordinateRegion, interactionModes: .all, showsUserLocation: false)
+                .overlay(alignment: .center) {
+                    Image(systemName: "pin.fill")
+                        .foregroundColor(.red)
+                }
+                .frame(width: 48, height: 48)
+        }
+    }
+}
+
+struct LocationView_Previews: PreviewProvider {
+    static var previews: some View {
+        LocationView(region: ActivityGeolocation(longitude: 46.3997, latitude: 8.1286))
+    }
+}

--- a/YonderTrips/YonderTrips/Presentation/ActivityDetail/ActivityDetail.swift
+++ b/YonderTrips/YonderTrips/Presentation/ActivityDetail/ActivityDetail.swift
@@ -42,7 +42,7 @@ struct ActivityDetail: View {
                 }
                 .padding(20)
                 
-                
+                ActivityCurriculumView()
             }
         }
         .background(.gray15)
@@ -69,7 +69,7 @@ extension ActivityDetail {
             
             HStack(spacing: 12) {
                 Text("스위스")
-                    .font(.yt(.pretendard(.body1)) .weight(.bold))
+                    .font(.yt(.pretendard(.body1)).weight(.bold))
                     .foregroundStyle(.gray60)
                 PointRewardTextView(pointReward: 200)
             }

--- a/YonderTrips/YonderTrips/Presentation/ActivityDetail/ActivityDetail.swift
+++ b/YonderTrips/YonderTrips/Presentation/ActivityDetail/ActivityDetail.swift
@@ -12,7 +12,7 @@ struct ActivityDetail: View {
     var body: some View {
         
         ScrollView {
-            VStack(alignment: .leading) {
+            VStack {
                 ZStack {
                     Image(.tripsPoster)
                         .resizable()
@@ -29,13 +29,20 @@ struct ActivityDetail: View {
                     )
                 }
                 
-                activityDetailInfoView()
-                    .padding(.top, -200)
-                    .padding(20)
+                VStack(alignment: .leading, spacing: 24) {
+                    activityDetailInfoView()
+                        .padding(.top, -200)
+                    
+                    restrictionInfoView()
+                        .frame(maxWidth: .infinity)
+                        .frame(alignment: .center)
+                    
+                    priceInfoView()
+                    
+                }
+                .padding(20)
                 
-                restrictionInfoView()
-                    .frame(maxWidth: .infinity)
-                    .frame(alignment: .center)
+                
             }
         }
         .background(.gray15)
@@ -136,6 +143,39 @@ extension ActivityDetail {
                 Text(value)
                     .foregroundStyle(.gray75)
                     .font(.yt(.pretendard(.body3)))
+            }
+        }
+    }
+    
+    func priceInfoView() -> some View {
+        
+        VStack(alignment: .leading, spacing: 10) {
+            
+            Text("341,000원")
+                .foregroundStyle(.gray45)
+                .font(.yt(.paperlogy(.caption1)))
+                .overlay {
+                    HStack {
+                        Image(.line)
+                            .frame(height: 16)
+                            .padding(.trailing, -25)
+                            .foregroundStyle(.blackSeafoam)
+                    }
+                    .padding(.top, 13)
+                }
+            
+            HStack(spacing: 8) {
+                Text("판매가")
+                    .foregroundStyle(.gray45)
+                    .font(.yt(.paperlogy(.body1)))
+                
+                Text("123,000원")
+                    .foregroundStyle(.gray75)
+                    .font(.yt(.paperlogy(.body1)))
+                
+                Text("63%")
+                    .foregroundStyle(.blackSeafoam)
+                    .font(.yt(.paperlogy(.body1)))
             }
         }
     }

--- a/YonderTrips/YonderTrips/Presentation/ActivityDetail/ActivityDetail.swift
+++ b/YonderTrips/YonderTrips/Presentation/ActivityDetail/ActivityDetail.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct ActivityDetail: View {
     
     var body: some View {
+        
         ScrollView {
             VStack(alignment: .leading) {
                 ZStack {
@@ -35,6 +36,13 @@ struct ActivityDetail: View {
         }
         .background(.gray0)
         .ignoresSafeArea()
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                FavoriteButtonView {
+                    print("Keep")
+                }
+            }
+        }
     }
 }
 

--- a/YonderTrips/YonderTrips/Presentation/ActivityDetail/ActivityDetail.swift
+++ b/YonderTrips/YonderTrips/Presentation/ActivityDetail/ActivityDetail.swift
@@ -21,7 +21,7 @@ struct ActivityDetail: View {
                     
                     LinearGradient(
                         gradient: Gradient(stops: [
-                            .init(color: Color.gray0, location: 0.15),
+                            .init(color: Color.gray15, location: 0.15),
                             .init(color: Color.clear, location: 0.65)
                         ]),
                         startPoint: .bottom,
@@ -32,9 +32,13 @@ struct ActivityDetail: View {
                 activityDetailInfoView()
                     .padding(.top, -200)
                     .padding(20)
+                
+                restrictionInfoView()
+                    .frame(maxWidth: .infinity)
+                    .frame(alignment: .center)
             }
         }
-        .background(.gray0)
+        .background(.gray15)
         .ignoresSafeArea()
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
@@ -95,6 +99,45 @@ extension ActivityDetail {
                 .font(.yt(.pretendard(.body3)))
         }
         .foregroundStyle(.gray45)
+    }
+    
+    func restrictionInfoView() -> some View {
+        
+        HStack(spacing: 20) {
+            restrictionInfoDetailView(.age, "연령 제한", "18세")
+            restrictionInfoDetailView(.height, "신장 제한", "150cm")
+            restrictionInfoDetailView(.people, "최대 참가 인원", "20명")
+        }
+        .padding()
+        .background(.gray0)
+        .clipShape(RoundedRectangle(cornerRadius: 15))
+        .overlay {
+            RoundedRectangle(cornerRadius: 15)
+                .stroke(.gray30, lineWidth: 0.6)
+        }
+    }
+    
+    func restrictionInfoDetailView(_ imageResource: ImageResource, _ title: String, _ value: String) -> some View {
+        
+        HStack {
+            Image(imageResource)
+                .resizable()
+                .frame(width: 24, height: 24)
+                .padding(8)
+                .foregroundStyle(.gray60)
+                .background(.gray15)
+                .cornerRadius(10)
+            
+            VStack(alignment: .leading) {
+                Text(title)
+                    .foregroundStyle(.gray45)
+                    .font(.yt(.pretendard(.caption2)))
+                
+                Text(value)
+                    .foregroundStyle(.gray75)
+                    .font(.yt(.pretendard(.body3)))
+            }
+        }
     }
 }
 

--- a/YonderTrips/YonderTrips/Presentation/ActivityDetail/ActivityDetail.swift
+++ b/YonderTrips/YonderTrips/Presentation/ActivityDetail/ActivityDetail.swift
@@ -1,0 +1,37 @@
+//
+//  ActivityDetail.swift
+//  YonderTrips
+//
+//  Created by 임윤휘 on 6/18/25.
+//
+
+import SwiftUI
+
+struct ActivityDetail: View {
+    
+    var body: some View {
+        ScrollView {
+            ZStack {
+                Image(.tripsPoster)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(maxWidth: .infinity)
+                
+                LinearGradient(
+                    gradient: Gradient(stops: [
+                        .init(color: Color.gray0, location: 0.15),
+                        .init(color: Color.clear, location: 0.65)
+                    ]),
+                    startPoint: .bottom,
+                    endPoint: .top
+                )
+            }
+            
+        }
+        .ignoresSafeArea()
+    }
+}
+
+#Preview {
+    ActivityDetail()
+}

--- a/YonderTrips/YonderTrips/Presentation/ActivityDetail/ActivityDetail.swift
+++ b/YonderTrips/YonderTrips/Presentation/ActivityDetail/ActivityDetail.swift
@@ -12,7 +12,7 @@ struct ActivityDetail: View {
     var body: some View {
         
         ScrollView {
-            VStack {
+            VStack(spacing: 10) {
                 ZStack {
                     Image(.tripsPoster)
                         .resizable()
@@ -43,7 +43,10 @@ struct ActivityDetail: View {
                 .padding(20)
                 
                 ActivityCurriculumView()
+                
+                ActivityReservationListView(reservations: ActivityReservationItem.dummyData)
             }
+            .padding(.bottom, 150)
         }
         .background(.gray15)
         .ignoresSafeArea()

--- a/YonderTrips/YonderTrips/Presentation/ActivityDetail/ActivityDetail.swift
+++ b/YonderTrips/YonderTrips/Presentation/ActivityDetail/ActivityDetail.swift
@@ -11,24 +11,82 @@ struct ActivityDetail: View {
     
     var body: some View {
         ScrollView {
-            ZStack {
-                Image(.tripsPoster)
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .frame(maxWidth: .infinity)
+            VStack(alignment: .leading) {
+                ZStack {
+                    Image(.tripsPoster)
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(maxWidth: .infinity)
+                    
+                    LinearGradient(
+                        gradient: Gradient(stops: [
+                            .init(color: Color.gray0, location: 0.15),
+                            .init(color: Color.clear, location: 0.65)
+                        ]),
+                        startPoint: .bottom,
+                        endPoint: .top
+                    )
+                }
                 
-                LinearGradient(
-                    gradient: Gradient(stops: [
-                        .init(color: Color.gray0, location: 0.15),
-                        .init(color: Color.clear, location: 0.65)
-                    ]),
-                    startPoint: .bottom,
-                    endPoint: .top
-                )
+                activityDetailInfoView()
+                    .padding(.top, -200)
+                    .padding(20)
+            }
+        }
+        .background(.gray0)
+        .ignoresSafeArea()
+    }
+}
+
+//MARK: - View
+extension ActivityDetail {
+    
+    func activityDetailInfoView() -> some View {
+        
+        VStack(alignment: .leading, spacing: 12) {
+            Text("겨울 스키 원정대")
+                .font(.yt(.paperlogy(.title1)))
+                .foregroundStyle(.gray90)
+            
+            HStack(spacing: 12) {
+                Text("스위스")
+                    .font(.yt(.pretendard(.body1)) .weight(.bold))
+                    .foregroundStyle(.gray60)
+                PointRewardTextView(pointReward: 200)
             }
             
+            Text("""
+                 끝없이 펼쳐진 슬로프 위에서, 자유롭게 바람을 가르는 짜릿한 시간.
+                 눈부신 설경 속에서 넘어지고, 웃고, 다시 일어서며
+                 당신만의 새싹 스키 리듬을 찾아 떠나보세요.
+                 작은 도전들이 쌓여 어느새 자유롭게 슬로프를 누비는
+                 순간을 만날 수 있을 거예요.
+                 """)
+            .font(.yt(.pretendard(.caption1)))
+            .foregroundStyle(.gray60)
+            .lineSpacing(6)
+            
+            HStack {
+                activityTotalCountView(.buy, "누적 구매", 135)
+                activityTotalCountView(.keepFill, "KEEP", 378)
+            }
         }
-        .ignoresSafeArea()
+    }
+    
+    func activityTotalCountView(_ imageResource: ImageResource, _ title: String, _ count: Int) -> some View {
+        
+        HStack(spacing: 2) {
+            Image(imageResource)
+                .resizable()
+                .frame(width: 16, height: 16)
+            
+            Text(title)
+                .font(.yt(.pretendard(.body3)))
+            
+            Text("\(count)회")
+                .font(.yt(.pretendard(.body3)))
+        }
+        .foregroundStyle(.gray45)
     }
 }
 

--- a/YonderTrips/YonderTrips/Presentation/ActivityDetail/ActivityDetailView.swift
+++ b/YonderTrips/YonderTrips/Presentation/ActivityDetail/ActivityDetailView.swift
@@ -1,5 +1,5 @@
 //
-//  ActivityDetail.swift
+//  ActivityDetailView.swift
 //  YonderTrips
 //
 //  Created by 임윤휘 on 6/18/25.
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct ActivityDetail: View {
+struct ActivityDetailView: View {
     
     var body: some View {
         
@@ -57,11 +57,18 @@ struct ActivityDetail: View {
                 }
             }
         }
+        .overlay {
+            
+            VStack {
+                Spacer()
+                paymentBottomView()
+            }
+        }
     }
 }
 
 //MARK: - View
-extension ActivityDetail {
+extension ActivityDetailView {
     
     func activityDetailInfoView() -> some View {
         
@@ -182,8 +189,45 @@ extension ActivityDetail {
             }
         }
     }
+    
+    func paymentBottomView() -> some View {
+        
+        VStack(spacing: 0) {
+            
+            Divider()
+            
+            HStack {
+                Text("123,000원")
+                    .font(.yt(.pretendard(.title1)))
+                    .foregroundColor(.gray90)
+                
+                Spacer()
+                
+                Button(action: handlePaymentButton) {
+                    Text("결제하기")
+                        .font(.yt(.pretendard(.title1)))
+                        .foregroundColor(.gray0)
+                        .padding(.vertical, 12)
+                        .padding(.horizontal, 30)
+                        .background(.blackSeafoam)
+                        .cornerRadius(6)
+                }
+            }
+            .padding(.horizontal, 20)
+            .padding(.top, 12)
+            .background(.gray0)
+        }
+    }
+}
+
+//MARK: - Action
+extension ActivityDetailView {
+    
+    func handlePaymentButton() {
+        print("결제하기")
+    }
 }
 
 #Preview {
-    ActivityDetail()
+    ActivityDetailView()
 }

--- a/YonderTrips/YonderTrips/Presentation/ActivityDetail/ActivityReservation/ActivityReservationListDateCellView.swift
+++ b/YonderTrips/YonderTrips/Presentation/ActivityDetail/ActivityReservation/ActivityReservationListDateCellView.swift
@@ -1,0 +1,42 @@
+//
+//  ActivityReservationListDateCellView.swift
+//  YonderTrips
+//
+//  Created by 임윤휘 on 6/19/25.
+//
+
+import SwiftUI
+
+struct ActivityReservationListDateCellView: View {
+    let date: Date
+    let isDisabled: Bool
+    @Binding var isSelected: Bool
+    
+    var body: some View {
+        Button(action: handleSelection) {
+            
+            Text("\(date.dayOfMonth)월 \(date.day)일")
+        }
+        .buttonStyle(ThreeStateButtonStyle(isSelected: isSelected, isDisabled: isDisabled))
+        .disabled(isDisabled)
+    }
+}
+
+//MARK: - Action
+extension ActivityReservationListDateCellView {
+    
+    func handleSelection() {
+        isSelected = true
+    }
+}
+
+struct ActivityReservationListCellView_Previews: PreviewProvider {
+    
+    static var previews: some View {
+        VStack {
+            ActivityReservationListDateCellView(date: Date(), isDisabled: true, isSelected: Binding(get: {false}, set: {_ in}))
+            ActivityReservationListDateCellView(date: Date(), isDisabled: false, isSelected: Binding(get: {true}, set: {_ in}))
+            ActivityReservationListDateCellView(date: Date(), isDisabled: false, isSelected: Binding(get: {false}, set: {_ in}))
+        }
+    }
+}

--- a/YonderTrips/YonderTrips/Presentation/ActivityDetail/ActivityReservation/ActivityReservationListTimeCellView.swift
+++ b/YonderTrips/YonderTrips/Presentation/ActivityDetail/ActivityReservation/ActivityReservationListTimeCellView.swift
@@ -1,0 +1,43 @@
+//
+//  ActivityReservationListTimeCellView.swift
+//  YonderTrips
+//
+//  Created by 임윤휘 on 6/19/25.
+//
+
+import SwiftUI
+
+struct ActivityReservationListTimeCellView: View {
+    let time: String
+    let isDisabled: Bool
+    @Binding var isSelected: Bool
+    
+    var body: some View {
+        Button(action: handleSelection) {
+            
+            Text(time)
+        }
+        .buttonStyle(ThreeStateButtonStyle(isSelected: isSelected, isDisabled: isDisabled))
+        .disabled(isDisabled)
+    }
+}
+
+//MARK: - Action
+extension ActivityReservationListTimeCellView {
+    
+    func handleSelection() {
+        print(#function)
+        isSelected = true
+    }
+}
+
+struct ActivityReservationListTimeCellView_Previews: PreviewProvider {
+    
+    static var previews: some View {
+        VStack {
+            ActivityReservationListTimeCellView(time: "10:00", isDisabled: true, isSelected: Binding(get: {false}, set: {_ in}))
+            ActivityReservationListTimeCellView(time: "10:00", isDisabled: false, isSelected: Binding(get: {true}, set: {_ in}))
+            ActivityReservationListTimeCellView(time: "10:00", isDisabled: false, isSelected: Binding(get: {false}, set: {_ in}))
+        }
+    }
+}

--- a/YonderTrips/YonderTrips/Presentation/ActivityDetail/ActivityReservation/ActivityReservationListView.swift
+++ b/YonderTrips/YonderTrips/Presentation/ActivityDetail/ActivityReservation/ActivityReservationListView.swift
@@ -1,0 +1,78 @@
+//
+//  ActivityReservationListView.swift
+//  YonderTrips
+//
+//  Created by 임윤휘 on 6/19/25.
+//
+
+import SwiftUI
+
+struct ActivityReservationListView: View {
+    
+    let reservations: [ActivityReservationItem]
+    @State var selectedItemName: String?
+    @State var selectedItemTime: String?
+    
+    private var selectedReservation: ActivityReservationItem? {
+        reservations.first{ $0.itemName == selectedItemName }
+    }
+    
+    private let colums: [GridItem] = Array(repeating: GridItem(.flexible(), spacing: 8), count: 4)
+    
+    var body: some View {
+        
+        VStack(spacing: 0) {
+            
+            SubheaderView(title: "액티비티 예약 설정")
+            
+            VStack(spacing: 16) {
+                ScrollView(.horizontal) {
+                    HStack {
+                        ForEach(reservations, id: \.itemName) { item in
+                            ActivityReservationListDateCellView(
+                                date: item.itemDate ?? Date(),
+                                isDisabled: item.isFullyReserved,
+                                isSelected: Binding(
+                                    get: { selectedItemName == item.itemName },
+                                    set: { _ in selectedItemName = item.itemName }
+                                )
+                            )
+                        }
+                    }
+                    .padding(.leading, 16)
+                }
+                .scrollIndicators(.hidden)
+                
+                if let times = selectedReservation?.times {
+                    
+                    LazyVGrid(columns: colums) {
+                        ForEach(times, id: \.self) { item in
+                            ActivityReservationListTimeCellView(
+                                time: item.time,
+                                isDisabled: item.isReserved,
+                                isSelected: Binding(
+                                    get: { selectedItemTime == item.time },
+                                    set: {_ in selectedItemTime = item.time}
+                                )
+                            )
+                        }
+                    }
+                    .padding(16)
+                    .background(.gray0)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 16)
+                            .stroke(.gray30, lineWidth: 1)
+                    )
+                    .cornerRadius(16)
+                    .padding(.horizontal, 16)
+                }
+            }
+            .animation(.easeInOut(duration: 0.4), value: selectedReservation)
+        }
+    }
+}
+
+#Preview {
+    
+    ActivityReservationListView(reservations: ActivityReservationItem.dummyData)
+}

--- a/YonderTrips/YonderTrips/Presentation/ActivityList/ActivityListCellView.swift
+++ b/YonderTrips/YonderTrips/Presentation/ActivityList/ActivityListCellView.swift
@@ -67,16 +67,7 @@ struct ActivityListCellView: View {
                             .foregroundStyle(.gray60)
                     }
                     
-                    HStack(spacing: 2) {
-                        Image(.point)
-                            .resizable()
-                            .frame(width: 20, height: 20)
-                            .foregroundStyle(.blackSeafoam)
-                        
-                        Text("\(activity.pointReward)P")
-                            .font(.yt(.paperlogy(.caption2)))
-                            .foregroundStyle(.gray60)
-                    }
+                    PointRewardTextView(pointReward: activity.pointReward)
                 }
                 .padding(.top, 16)
                 

--- a/YonderTrips/YonderTrips/Presentation/DesignSystem/ButtonStyle/ThreeStateButtonStyle.swift
+++ b/YonderTrips/YonderTrips/Presentation/DesignSystem/ButtonStyle/ThreeStateButtonStyle.swift
@@ -1,0 +1,32 @@
+//
+//  ThreeStateButtonStyle.swift
+//  YonderTrips
+//
+//  Created by 임윤휘 on 6/19/25.
+//
+
+import SwiftUI
+
+struct ThreeStateButtonStyle: ButtonStyle {
+    
+    let isSelected: Bool
+    let isDisabled: Bool
+    
+    func makeBody(configuration: Configuration) -> some View {
+        
+        configuration.label
+            .font(.system(size: 14))
+            .foregroundStyle(isDisabled ? .gray45 : (isSelected ? .deepSeafoam : .gray75))
+            .padding(8)
+            .frame(width: 80, height: 40)
+            .background(
+                isDisabled ? .gray15 :
+                    (isSelected ? .lightSeafoam : .gray0)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 20)
+                    .stroke(isDisabled ? .gray30 : (isSelected ? .deepSeafoam : .gray30), lineWidth: 1)
+            )
+            .cornerRadius(20)
+    }
+}

--- a/YonderTrips/YonderTrips/Presentation/DesignSystem/Component/Header/HeaderView.swift
+++ b/YonderTrips/YonderTrips/Presentation/DesignSystem/Component/Header/HeaderView.swift
@@ -46,10 +46,4 @@ struct HeaderView<Label>: View where Label: View {
         .padding(16)
     }
 }
-//
-//#Preview {
-//    HeaderView(title: "NewActivity", buttonTitle: "View All") {
-//        print("did Button Tapped")
-//    }
-//}
 

--- a/YonderTrips/YonderTrips/Presentation/DesignSystem/Component/Header/SubheaderView.swift
+++ b/YonderTrips/YonderTrips/Presentation/DesignSystem/Component/Header/SubheaderView.swift
@@ -1,0 +1,29 @@
+//
+//  SubheaderView.swift
+//  YonderTrips
+//
+//  Created by 임윤휘 on 6/18/25.
+//
+
+import SwiftUI
+
+struct SubheaderView: View {
+    
+    let title: String
+    
+    var body: some View {
+        
+        HStack {
+            Text(title)
+                .font(Font.yt(.pretendard(.body2)).weight(.bold))
+                .foregroundStyle(.gray45)
+            
+            Spacer()
+        }
+        .padding(16)
+    }
+}
+
+#Preview {
+    SubheaderView(title: "액티비티 커리큘럼")
+}

--- a/YonderTrips/YonderTrips/Presentation/DesignSystem/Component/PointRewardTextView.swift
+++ b/YonderTrips/YonderTrips/Presentation/DesignSystem/Component/PointRewardTextView.swift
@@ -1,0 +1,32 @@
+//
+//  PointRewardTextView.swift
+//  YonderTrips
+//
+//  Created by 임윤휘 on 6/18/25.
+//
+
+import SwiftUI
+
+struct PointRewardTextView: View {
+    
+    let pointReward: Int
+    
+    var body: some View {
+        
+        HStack(spacing: 2) {
+            Image(.point)
+                .resizable()
+                .frame(width: 20, height: 20)
+                .foregroundStyle(.blackSeafoam)
+            
+            Text("\(pointReward)P")
+                .font(.yt(.paperlogy(.caption2)))
+                .foregroundStyle(.gray60)
+        }
+
+    }
+}
+
+#Preview {
+    PointRewardTextView(pointReward: 100)
+}

--- a/YonderTrips/YonderTrips/Presentation/DesignSystem/Extension/Date+.swift
+++ b/YonderTrips/YonderTrips/Presentation/DesignSystem/Extension/Date+.swift
@@ -1,0 +1,18 @@
+//
+//  Date+.swift
+//  YonderTrips
+//
+//  Created by 임윤휘 on 6/19/25.
+//
+
+import Foundation
+
+extension Date {
+    var dayOfMonth: Int {
+        Calendar.current.component(.month, from: self)
+    }
+    
+    var day: Int {
+        Calendar.current.component(.day, from: self)
+    }
+}

--- a/YonderTrips/YonderTrips/Preview Content/DummyData/ActivityReservationItem+.swift
+++ b/YonderTrips/YonderTrips/Preview Content/DummyData/ActivityReservationItem+.swift
@@ -1,0 +1,105 @@
+//
+//  ActivityReservationItem+.swift
+//  YonderTrips
+//
+//  Created by 임윤휘 on 6/19/25.
+//
+
+import Foundation
+
+extension ActivityReservationItem {
+    
+    static let dummyData: [ActivityReservationItem] = [
+        ActivityReservationItem(
+            itemName: "2025-07-01",
+            times: [
+                ActivityReservationTime(time: "10:00", isReserved: true),
+                ActivityReservationTime(time: "11:00", isReserved: true),
+                ActivityReservationTime(time: "12:00", isReserved: true),
+                ActivityReservationTime(time: "13:00", isReserved: true),
+                ActivityReservationTime(time: "14:00", isReserved: true),
+                ActivityReservationTime(time: "15:00", isReserved: true),
+                ActivityReservationTime(time: "16:00", isReserved: true),
+                ActivityReservationTime(time: "17:00", isReserved: true)
+            ]
+        ),
+        ActivityReservationItem(
+            itemName: "2025-07-02",
+            times: [
+                ActivityReservationTime(time: "10:00", isReserved: false),
+                ActivityReservationTime(time: "11:00", isReserved: true),
+                ActivityReservationTime(time: "12:00", isReserved: false),
+                ActivityReservationTime(time: "13:00", isReserved: false),
+                ActivityReservationTime(time: "14:00", isReserved: false),
+                ActivityReservationTime(time: "15:00", isReserved: false),
+                ActivityReservationTime(time: "16:00", isReserved: false),
+                ActivityReservationTime(time: "17:00", isReserved: false)
+            ]
+        ),
+        ActivityReservationItem(
+            itemName: "2025-07-03",
+            times: [
+                ActivityReservationTime(time: "10:00", isReserved: false),
+                ActivityReservationTime(time: "11:00", isReserved: false),
+                ActivityReservationTime(time: "12:00", isReserved: false),
+                ActivityReservationTime(time: "13:00", isReserved: false),
+                ActivityReservationTime(time: "14:00", isReserved: false),
+                ActivityReservationTime(time: "15:00", isReserved: false),
+                ActivityReservationTime(time: "16:00", isReserved: false),
+                ActivityReservationTime(time: "17:00", isReserved: false)
+            ]
+        ),
+        ActivityReservationItem(
+            itemName: "2025-07-04",
+            times: [
+                ActivityReservationTime(time: "10:00", isReserved: false),
+                ActivityReservationTime(time: "11:00", isReserved: false),
+                ActivityReservationTime(time: "12:00", isReserved: false),
+                ActivityReservationTime(time: "13:00", isReserved: false),
+                ActivityReservationTime(time: "14:00", isReserved: false),
+                ActivityReservationTime(time: "15:00", isReserved: false),
+                ActivityReservationTime(time: "16:00", isReserved: false),
+                ActivityReservationTime(time: "17:00", isReserved: false)
+            ]
+        ),
+        ActivityReservationItem(
+            itemName: "2025-07-05",
+            times: [
+                ActivityReservationTime(time: "10:00", isReserved: false),
+                ActivityReservationTime(time: "11:00", isReserved: false),
+                ActivityReservationTime(time: "12:00", isReserved: false),
+                ActivityReservationTime(time: "13:00", isReserved: false),
+                ActivityReservationTime(time: "14:00", isReserved: false),
+                ActivityReservationTime(time: "15:00", isReserved: false),
+                ActivityReservationTime(time: "16:00", isReserved: false),
+                ActivityReservationTime(time: "17:00", isReserved: false)
+            ]
+        ),
+        ActivityReservationItem(
+            itemName: "2025-07-06",
+            times: [
+                ActivityReservationTime(time: "10:00", isReserved: false),
+                ActivityReservationTime(time: "11:00", isReserved: false),
+                ActivityReservationTime(time: "12:00", isReserved: false),
+                ActivityReservationTime(time: "13:00", isReserved: false),
+                ActivityReservationTime(time: "14:00", isReserved: false),
+                ActivityReservationTime(time: "15:00", isReserved: false),
+                ActivityReservationTime(time: "16:00", isReserved: false),
+                ActivityReservationTime(time: "17:00", isReserved: false)
+            ]
+        ),
+        ActivityReservationItem(
+            itemName: "2025-07-07",
+            times: [
+                ActivityReservationTime(time: "10:00", isReserved: false),
+                ActivityReservationTime(time: "11:00", isReserved: false),
+                ActivityReservationTime(time: "12:00", isReserved: false),
+                ActivityReservationTime(time: "13:00", isReserved: false),
+                ActivityReservationTime(time: "14:00", isReserved: false),
+                ActivityReservationTime(time: "15:00", isReserved: false),
+                ActivityReservationTime(time: "16:00", isReserved: false),
+                ActivityReservationTime(time: "17:00", isReserved: false)
+            ]
+        )
+    ]
+}

--- a/YonderTrips/YonderTrips/Resource/Assets.xcassets/Components/Line.imageset/Contents.json
+++ b/YonderTrips/YonderTrips/Resource/Assets.xcassets/Components/Line.imageset/Contents.json
@@ -3,16 +3,49 @@
     {
       "filename" : "Property 1=Line 3.png",
       "idiom" : "universal",
+      "resizing" : {
+        "cap-insets" : {
+          "left" : 12,
+          "right" : 31
+        },
+        "center" : {
+          "mode" : "stretch",
+          "width" : 1
+        },
+        "mode" : "3-part-horizontal"
+      },
       "scale" : "1x"
     },
     {
       "filename" : "Property 1=Line 3@2x.png",
       "idiom" : "universal",
+      "resizing" : {
+        "cap-insets" : {
+          "left" : 26,
+          "right" : 57
+        },
+        "center" : {
+          "mode" : "stretch",
+          "width" : 1
+        },
+        "mode" : "3-part-horizontal"
+      },
       "scale" : "2x"
     },
     {
       "filename" : "Property 1=Line 3@3x.png",
       "idiom" : "universal",
+      "resizing" : {
+        "cap-insets" : {
+          "left" : 42,
+          "right" : 50
+        },
+        "center" : {
+          "mode" : "stretch",
+          "width" : 1
+        },
+        "mode" : "3-part-horizontal"
+      },
       "scale" : "3x"
     }
   ],

--- a/YonderTrips/YonderTrips/Resource/Assets.xcassets/TabBar/Keep_Fill.imageset/Contents.json
+++ b/YonderTrips/YonderTrips/Resource/Assets.xcassets/TabBar/Keep_Fill.imageset/Contents.json
@@ -19,5 +19,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }


### PR DESCRIPTION
## related
#30 

<br>


## 구현

- 액티비티 상세 화면 UI 구성
- YTDateFormatter 생성
```Swift
struct YTDateFormatter {
    
    enum Format {
        case iso8601
        case yyyyMMdd
    }
    
    static private let iso8601Formatter: DateFormatter = { ... }()
    
    static private let yyyyMMddFormatter: DateFormatter = { ... }()
    
    static func string(from date: Date, format: Format) -> String { ... }
    
    static func date(from string: String, format: Format) -> Date? { ... }
}
```

- ActivityReservationItem 더미 데이터 생성
- ActivityReservationItem 프로퍼티 확장
```Swift

extension ActivityReservationItem {

    var itemDate: Date? { ... }

    var isFullyReserved: Bool { ... }
}
```

<br>

## 이슈
- 이미지 목록, 문의하기 버튼 추후 구현




<br>

## 미리보기


| 미리보기 | 미리보기 | 미리보기 |
| ----- | ----- | ----- |
| <img src = "https://github.com/user-attachments/assets/0c176a3e-5958-4461-901d-b2a8f55e1967" width = 260 height = 560> | <img src = "https://github.com/user-attachments/assets/20d9f2d7-e213-4206-a13a-7a9ade946766" width = 260 height = 560> | <img src = "https://github.com/user-attachments/assets/9ea16e74-355c-4238-b42f-987572c18d9c" width = 260 height = 560> |


closed #30 

<br>
